### PR TITLE
Make key parsing a proper middleware (w/o args)

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -3,11 +3,12 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/gocql/gocql"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/gocql/gocql"
 )
 
 type mockStore struct {
@@ -42,21 +43,22 @@ func NewMockStore() *mockStore {
 
 const prefixUri = "/sessions/v1/"
 
-func SetUp (t *testing.T) (http.Handler, Store) {
-	store   := NewMockStore()
-	logger  := NewLogger("http_test")
+func SetUp(t *testing.T) (http.Handler, Store) {
+	store := NewMockStore()
+	logger := NewLogger("http_test")
 	handler := HttpHandler{store, &logger}
-	handle  := ParseKeyMiddleware(prefixUri, http.HandlerFunc(handler.Dispatch))
+	middleware := NewParseKeyMiddleware(prefixUri)
+	handle := middleware(http.HandlerFunc(handler.Dispatch))
 
 	return handle, store
 }
 
 func TestGetSuccess(t *testing.T) {
 	handler, store := SetUp(t)
-	url            := fmt.Sprintf("%sfoo", prefixUri)
-	req            := httptest.NewRequest("GET", url, nil)
-	rr             := httptest.NewRecorder()
-	expected       := "bar"
+	url := fmt.Sprintf("%sfoo", prefixUri)
+	req := httptest.NewRequest("GET", url, nil)
+	rr := httptest.NewRecorder()
+	expected := "bar"
 
 	store.Set("foo", []byte("bar"))
 
@@ -73,10 +75,9 @@ func TestGetSuccess(t *testing.T) {
 
 func TestGetNotFound(t *testing.T) {
 	handler, _ := SetUp(t)
-	url        := fmt.Sprintf("%scat", prefixUri)
-	req        := httptest.NewRequest("GET", url, nil)
-	rr         := httptest.NewRecorder()
-
+	url := fmt.Sprintf("%scat", prefixUri)
+	req := httptest.NewRequest("GET", url, nil)
+	rr := httptest.NewRecorder()
 
 	handler.ServeHTTP(rr, req)
 
@@ -87,10 +88,10 @@ func TestGetNotFound(t *testing.T) {
 
 func TestPost(t *testing.T) {
 	handler, store := SetUp(t)
-	url            := fmt.Sprintf("%scat", prefixUri)
-	body           := strings.NewReader("meow")
-	req            := httptest.NewRequest("POST", url, body)
-	rr             := httptest.NewRecorder()
+	url := fmt.Sprintf("%scat", prefixUri)
+	body := strings.NewReader("meow")
+	req := httptest.NewRequest("POST", url, body)
+	rr := httptest.NewRecorder()
 
 	handler.ServeHTTP(rr, req)
 
@@ -108,9 +109,9 @@ func TestPost(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	handler, store := SetUp(t)
-	url            := fmt.Sprintf("%scat", prefixUri)
-	req            := httptest.NewRequest("DELETE", url, nil)
-	rr             := httptest.NewRecorder()
+	url := fmt.Sprintf("%scat", prefixUri)
+	req := httptest.NewRequest("DELETE", url, nil)
+	rr := httptest.NewRecorder()
 
 	store.Set("cat", []byte("meow"))
 

--- a/kask.go
+++ b/kask.go
@@ -25,12 +25,14 @@ func main() {
 		log.Fatal("Error connecting to Cassandra: ", err)
 	}
 
+	keyMiddleware := NewParseKeyMiddleware(config.BaseUri)
 	handler := HttpHandler{store, &logger}
+	dispatcher := keyMiddleware(http.HandlerFunc(handler.Dispatch))
 	address := fmt.Sprintf("%s:%d", config.Address, config.Port)
 
 	logger.Info("Starting service as http://%s%s", address, config.BaseUri)
 
-	http.Handle(config.BaseUri, ParseKeyMiddleware(config.BaseUri, http.HandlerFunc(handler.Dispatch)))
+	http.Handle(config.BaseUri, dispatcher)
 	log.Fatal(http.ListenAndServe(address, nil))
 
 	defer store.Close()


### PR DESCRIPTION
(also fixes a warning caused by an ambiguous context key)