### PR TITLE
Various fixes to appease `go lint`

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,6 +8,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+// Config represents an application-wide configuration.
 type Config struct {
 	ServiceName string `yaml:"service_name"`
 	BaseURI     string `yaml:"base_uri"`
@@ -23,6 +24,7 @@ type Config struct {
 	}
 }
 
+// ReadConfig returns a new Config from a YAML file.
 func ReadConfig(filename string) (*Config, error) {
 	data, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -31,6 +33,7 @@ func ReadConfig(filename string) (*Config, error) {
 	return NewConfig(data)
 }
 
+// NewConfig returns a new Config from YAML serialized as bytes.
 func NewConfig(data []byte) (*Config, error) {
 	// Populate a new Config with sane defaults
 	config := Config{

--- a/http_test.go
+++ b/http_test.go
@@ -47,7 +47,7 @@ func setUp(t *testing.T) (http.Handler, Store) {
 	store := newMockStore()
 	config, _ := NewConfig([]byte("default_ttl: 300000"))
 	logger := NewLogger("http_test")
-	handler := HttpHandler{store, config, logger}
+	handler := HTTPHandler{store, config, logger}
 	middleware := NewParseKeyMiddleware(prefixURI)
 	handle := middleware(http.HandlerFunc(handler.Dispatch))
 

--- a/kask.go
+++ b/kask.go
@@ -26,7 +26,7 @@ func main() {
 	}
 
 	keyMiddleware := NewParseKeyMiddleware(config.BaseURI)
-	handler := HttpHandler{store, config, logger}
+	handler := HTTPHandler{store, config, logger}
 	dispatcher := keyMiddleware(http.HandlerFunc(handler.Dispatch))
 	address := fmt.Sprintf("%s:%d", config.Address, config.Port)
 

--- a/logging.go
+++ b/logging.go
@@ -6,30 +6,37 @@ import (
 	"log/syslog"
 )
 
+// Logger formats and delivers log messages.
 type Logger struct {
 	writer *syslog.Writer
 }
 
+// Critical logs messages of severity CRITICAL.
 func (l *Logger) Critical(format string, v ...interface{}) {
 	l.writer.Crit(fmt.Sprintf(format, v...))
 }
 
+// Error logs messages of severity ERROR.
 func (l *Logger) Error(format string, v ...interface{}) {
 	l.writer.Err(fmt.Sprintf(format, v...))
 }
 
+// Warning logs messages of severity WARNING.
 func (l *Logger) Warning(format string, v ...interface{}) {
 	l.writer.Warning(fmt.Sprintf(format, v...))
 }
 
+// Info logs messages of severity INFO.
 func (l *Logger) Info(format string, v ...interface{}) {
 	l.writer.Info(fmt.Sprintf(format, v...))
 }
 
+// Debug logs messages of severity DEBUG.
 func (l *Logger) Debug(format string, v ...interface{}) {
 	l.writer.Debug(fmt.Sprintf(format, v...))
 }
 
+// NewLogger constructs new instances of Logger.
 func NewLogger(serviceName string) *Logger {
 	writer, err := syslog.Dial("", "", syslog.LOG_WARNING|syslog.LOG_DAEMON, serviceName)
 	if err != nil {


### PR DESCRIPTION
* Docstrings
* Function/Struct naming conventions